### PR TITLE
posix: Use capi for ioctl foreign import

### DIFF
--- a/platform/posix/src/System/Terminal/Platform.hsc
+++ b/platform/posix/src/System/Terminal/Platform.hsc
@@ -302,8 +302,8 @@ foreign import ccall unsafe "tcgetattr"
 foreign import ccall unsafe "tcsetattr"
   unsafeSetTermios :: CInt -> CInt -> Ptr Termios -> IO CInt
 
-foreign import ccall unsafe "ioctl"
-  unsafeIOCtl :: CInt -> CInt -> Ptr a -> IO CInt
+foreign import capi unsafe "ioctl"
+  unsafeIOCtl :: CInt -> CULong -> Ptr a -> IO CInt
 
 foreign import ccall unsafe
   stg_sig_install :: CInt -> CInt -> Ptr a -> IO CInt


### PR DESCRIPTION
As described in this draft blog post [1], ccall does not support
variadic functions such as `ioctl`.

[1]: https://gitlab.haskell.org/ghc/homepage/-/merge_requests/86