### PR TITLE
Update capi PR #15

### DIFF
--- a/example/terminal-ev/Main.hs
+++ b/example/terminal-ev/Main.hs
@@ -7,7 +7,7 @@ import           Control.Monad.IO.Class
 import           Data.Char
 import           Data.Function             (fix)
 
-import           Data.Text.Prettyprint.Doc
+import           Prettyprinter
 import           System.Terminal
 
 main :: IO ()
@@ -27,7 +27,7 @@ main = withTerminal $ runTerminalT $ do
           KeyEvent {}           -> putDocLn $ annotate (foreground $ bright blue)    (pretty $ show ev)
           WindowEvent {}        -> do
             sz <- getWindowSize
-            putDocLn $ annotate (foreground $ bright magenta) (pretty $ show ev <> ": " <> show sz) 
+            putDocLn $ annotate (foreground $ bright magenta) (pretty $ show ev <> ": " <> show sz)
           _ ->                     putDocLn $ pretty $ show ev
         flush
         loop

--- a/platform/posix/src/System/Terminal/Platform.hsc
+++ b/platform/posix/src/System/Terminal/Platform.hsc
@@ -303,8 +303,8 @@ foreign import ccall unsafe "tcgetattr"
 foreign import ccall unsafe "tcsetattr"
   unsafeSetTermios :: CInt -> CInt -> Ptr Termios -> IO CInt
 
-foreign import ccall unsafe "ioctl"
-  unsafeIOCtl :: CInt -> CInt -> Ptr a -> IO CInt
+foreign import capi unsafe "ioctl"
+  unsafeIOCtl :: CInt -> CULong -> Ptr a -> IO CInt
 
 foreign import ccall unsafe
   stg_sig_install :: CInt -> CInt -> Ptr a -> IO CInt

--- a/platform/posix/src/System/Terminal/Platform.hsc
+++ b/platform/posix/src/System/Terminal/Platform.hsc
@@ -1,3 +1,4 @@
+{-# LANGUAGE CApiFFI #-}
 module System.Terminal.Platform
     ( withTerminal
     , LocalTerminal ()
@@ -64,7 +65,7 @@ withTerminal action = do
     withTermiosSettings $ \termios->
         withInterruptHandler (handleInterrupt mainThread interrupt) $
         withResizeHandler (handleResize windowChanged) $
-        withInputProcessing termios cursorPosition events $ 
+        withInputProcessing termios cursorPosition events $
         action LocalTerminal
             { localType = term
             , localEvent = do
@@ -159,7 +160,7 @@ withInputProcessing termios cursorPosition events =
                   -- There are sequences depending on timing (escape either is literal
                   -- escape or the beginning of a sequence).
                   -- This block evaluates whether more input is available within
-                  -- a limited timespan. If this is the case it just recurses 
+                  -- a limited timespan. If this is the case it just recurses
                   -- with the decoder continuation.
                   -- Otherwise, a NUL character is fed in order to tell the decoder
                   -- that there is no more input belonging to the sequence.
@@ -212,7 +213,7 @@ getWindowSize =
       _ -> undefined
 
 getTermios :: IO Termios
-getTermios = 
+getTermios =
   alloca $ \ptr->
     unsafeGetTermios 0 ptr >>= \case
       0 -> peek ptr
@@ -222,7 +223,7 @@ setTermios :: Termios -> IO ()
 setTermios t =
   alloca $ \ptr->
     unsafeGetTermios 0 ptr >>= \case
-      0 -> do 
+      0 -> do
         poke ptr t
         unsafeSetTermios 0 (#const TCSANOW) ptr >>= \case
           0 -> pure ()
@@ -277,7 +278,7 @@ instance Storable Termios where
       peekVINTR      = (#peek struct termios, c_cc[VINTR])  ptr :: IO CUChar
       peekVKILL      = (#peek struct termios, c_cc[VKILL])  ptr :: IO CUChar
       peekVQUIT      = (#peek struct termios, c_cc[VQUIT])  ptr :: IO CUChar
-      peekLFlag      = (#peek struct termios, c_lflag)      ptr :: IO CUInt 
+      peekLFlag      = (#peek struct termios, c_lflag)      ptr :: IO CUInt
   poke ptr termios = do
     pokeVEOF   $ fromIntegral $ fromEnum $ termiosVEOF   termios
     pokeVERASE $ fromIntegral $ fromEnum $ termiosVERASE termios


### PR DESCRIPTION
Following up on #15 

Adding the CApiFFI extension seems necessary, and the `terminal-ev` example didn't build because of a deprecated Prettyprinter module name.