### PR TITLE
Change decoder to not print 2 chars on overidden keycodes

### DIFF
--- a/src/System/Terminal/Decoder.hs
+++ b/src/System/Terminal/Decoder.hs
@@ -30,15 +30,15 @@ defaultDecoder specialChar = defaultMode
         | c == '\ESC' -> (escapeMode, [])
         -- All other C0 control codes are mapped to their corresponding ASCII character + CTRL modifier.
         -- If the character is a special character, then two events are produced.
-        | c <= '\US'  -> emit $ maybe [KeyEvent (CharKey (toEnum $ (+64) $ fromEnum c)) (mods <> ctrlKey)] pure (specialChar mods c)
+        | c <= '\US'  -> emit $ f [KeyEvent (CharKey (toEnum $ (+64) $ fromEnum c)) (mods <> ctrlKey)] mods c
         -- All remaning characters of the Latin-1 block are returned as is.
-        | c <  '\DEL' -> emit $ [KeyEvent (CharKey c) mods] ++ f mods c
+        | c <  '\DEL' -> emit $ f [KeyEvent (CharKey c) mods] mods c
         -- Skip all other C1 control codes and DEL unless they have special meaning configured.
-        | c <  '\xA0' -> emit $ f mods c
+        | c <  '\xA0' -> emit $ f [] mods c
         -- All other Unicode characters are returned as is.
-        | otherwise   -> emit [KeyEvent (CharKey c) mods]
+        | otherwise   -> emit $ f [KeyEvent (CharKey c) mods] mods c
         where
-            f mods c = maybe [] pure (specialChar mods c)
+            f els mods c = maybe els pure (specialChar mods c)
 
     pasteMode :: Decoder
     pasteMode = awaitEsc

--- a/src/System/Terminal/Decoder.hs
+++ b/src/System/Terminal/Decoder.hs
@@ -30,7 +30,7 @@ defaultDecoder specialChar = defaultMode
         | c == '\ESC' -> (escapeMode, [])
         -- All other C0 control codes are mapped to their corresponding ASCII character + CTRL modifier.
         -- If the character is a special character, then two events are produced.
-        | c <= '\US'  -> emit $ [KeyEvent (CharKey (toEnum $ (+64) $ fromEnum c)) (mods <> ctrlKey)] ++ f mods c
+        | c <= '\US'  -> emit $ maybe [KeyEvent (CharKey (toEnum $ (+64) $ fromEnum c)) (mods <> ctrlKey)] pure (specialChar mods c)
         -- All remaning characters of the Latin-1 block are returned as is.
         | c <  '\DEL' -> emit $ [KeyEvent (CharKey c) mods] ++ f mods c
         -- Skip all other C1 control codes and DEL unless they have special meaning configured.


### PR DESCRIPTION
As documented in #17, certain keycodes which are otherwise handled by the `specialChar` function are still producing an additional character. This changes that behaviour such that if a key is otherwise handled by `specialChar` it will not also produce an event for it's ASCII code, as it seems strange to do that when there is already an enum representing the key.

There is an additional fix in the PR for the windows Platform.hsc file as it seems to have been missed in a previous change and no longer compiles.

Closes #17